### PR TITLE
fix json decode error handling

### DIFF
--- a/ganb.go
+++ b/ganb.go
@@ -178,8 +178,8 @@ func (g Ganb) OpenIDGetToken(redirectURI string, code string, authMethod string)
 		return token, errors.Wrap(err, "failed to Http Request.")
 	}
 
-	jsonErr := json.Unmarshal(body, &token)
-	if jsonErr != nil {
+	err = json.Unmarshal(body, &token)
+	if err != nil {
 		return token, errors.Wrap(err, "failed to unmarshal json.")
 	}
 


### PR DESCRIPTION
Before this PR, OpenIDGetToken  returns err = nil when json.Unmarshal fails, so fix that.